### PR TITLE
Version 1.0.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,19 +7,20 @@ TRACE_GEN := $(TOOLSDIR)/make_sample_trace.cpp
 SRCS := $(filter-out $(MAIN), $(wildcard $(SRCDIR)/*.cpp))
 OBJS := $(patsubst $(SRCDIR)/%.cpp, $(OBJDIR)/%.o, $(SRCS))
 
-CXX_COMMON_FLAGS := -std=c++11
-CXXFLAGS := -Og -g -Wall $(CXX_COMMON_FLAGS)
+CXXFLAGS += -std=c++11
 
-.PHONY: all clean depend
+.PHONY: all clean depend debug backend
 
-all: depend vampire sampletr
+# all: Default compilation rule, generates binary with optimzation, not suitable for debugging
+all: CXXFLAGS += -O3 -march=native
+all: backend
 
-debug: all
-ifeq ($(CXX), clang++)
-CXXFLAGS := -O0 -g $(CXX_COMMON_FLAGS)
-else
-CXXFLAGS := -Og -g $(CXX_COMMON_FLAGS)
-endif
+# debug: Generates a binary which is easier to debug
+debug: CXXFLAGS += -O0 -g
+debug: backend
+
+# Actual compilation is handled by function past this comment
+backend: depend vampire sampletr
 
 sampletr: traceGen
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ and is compatible with widely-used memory simulators such as
 [Ramulator](https://github.com/CMU-SAFARI/ramulator/) and
 [DRAMSim2](https://github.com/umd-memsys/DRAMSim2/).
 
-*Current version: 1.0.0 (released October 10, 2018)*
+*Current version: 1.0.1 (released October 13, 2018)*
 
 
 ## Key Features

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -18,8 +18,8 @@ Released under the MIT License
 #include "helper.h"
 
 Config::Config() {
-    setBitDist.reset(new std::vector<float>(0));
-    toggleDist.reset(new std::vector<float>(0));
+    setBitDist.assign({});
+    toggleDist.assign({});
 }
 
 Config::Config(const std::string& fname) : Config() {
@@ -90,8 +90,8 @@ void Config::parse(const std::string& fname) {
             // Convert std::vector<std::string> to std::vector<float>
             assert(tokens.size() == (NUM_OF_BITS+1+1) && "Distribution should have exactly 513 values.");
 
-            setBitDist->resize(tokens.size()-1); // -1 for the key
-            std::transform(tokens.begin()+1, tokens.end(), setBitDist->begin(), [](const std::string& val)
+            setBitDist.resize(tokens.size()-1); // -1 for the key
+            std::transform(tokens.begin()+1, tokens.end(), setBitDist.begin(), [](const std::string& val)
             {
                 return std::stof(val);
             });
@@ -99,8 +99,8 @@ void Config::parse(const std::string& fname) {
             // Convert std::vector<std::string> to std::vector<float>
             assert(tokens.size() == (NUM_OF_BITS+1+1) && "Distribution should have exactly 513 values.");
 
-            toggleDist->resize(tokens.size()-1); // -1 for the key
-            std::transform(tokens.begin()+1, tokens.end(), toggleDist->begin(), [](const std::string& val)
+            toggleDist.resize(tokens.size()-1); // -1 for the key
+            std::transform(tokens.begin()+1, tokens.end(), toggleDist.begin(), [](const std::string& val)
             {
                 return std::stof(val);
             });
@@ -238,20 +238,20 @@ void Config::setToggleArrSizeMult(int toggleArrSizeMult) {
     Config::toggleArrSizeMult = toggleArrSizeMult;
 }
 
-std::vector<float> *Config::getSetBitDist() const {
-    return setBitDist.get();
+std::vector<float> *Config::getSetBitDist() {
+    return &setBitDist;
 }
 
 void Config::setSetBitDist(std::vector<float> *setBitDist) {
-    Config::setBitDist.reset(setBitDist);
+    Config::setBitDist = (*setBitDist);
 }
 
-std::vector<float> *Config::getToggleDist() const {
-    return toggleDist.get();
+std::vector<float> *Config::getToggleDist() {
+    return &toggleDist;
 }
 
 void Config::setToggleDist(std::vector<float> *toggleDist) {
-    Config::toggleDist.reset(toggleDist);
+    Config::toggleDist = (*toggleDist);
 }
 
 int Config::getAvgNumSetBits() const {

--- a/src/config.h
+++ b/src/config.h
@@ -36,8 +36,8 @@ private:
     int setBitArrSizeMult = 1000;
     int toggleArrSizeMult = 1000;
 
-    std::shared_ptr<std::vector<float>> setBitDist;
-    std::shared_ptr<std::vector<float>> toggleDist;
+    std::vector<float> setBitDist;
+    std::vector<float> toggleDist;
 
     /* For TraceType::RATIO */
     int avgNumSetBits    = 0;
@@ -89,10 +89,10 @@ public:
     int getToggleArrSizeMult() const;
     void setToggleArrSizeMult(int toggleArrSizeMult);
 
-    std::vector<float> *getSetBitDist() const;
+    std::vector<float> *getSetBitDist();
     void setSetBitDist(std::vector<float> *setBitDist);
 
-    std::vector<float> *getToggleDist() const;
+    std::vector<float> *getToggleDist();
     void setToggleDist(std::vector<float> *toggleDist);
 
     int getAvgNumSetBits() const;

--- a/src/equations.cpp
+++ b/src/equations.cpp
@@ -19,15 +19,15 @@ Released under the MIT License
 /********************************************************************/
 void Equations::init_struct_var() {
     /* Initialize RD current values for the 8 banks */
-    rdStructVarCurrent[int(VendorType::A)].reset(new float[8]{
+    rdStructVarCurrent[int(VendorType::A)].assign({
             241.6258f/241.6258f, 243.7769f/241.6258f, 255.7692f/241.6258f, 259.8341f/241.6258f,
             243.5455f/241.6258f, 246.2226f/241.6258f, 256.0077f/241.6258f, 260.2505f/241.6258f
     });
-    rdStructVarCurrent[int(VendorType::B)].reset(new float[8]{
+    rdStructVarCurrent[int(VendorType::B)].assign({
             222.4698f/222.4698f, 228.8632f/222.4698f, 225.5057f/222.4698f, 226.3366f/222.4698f,
             227.9259f/222.4698f, 225.7385f/222.4698f, 225.361f/222.4698f, 231.3116f/222.4698f
     });
-    rdStructVarCurrent[int(VendorType::C)].reset(new float[8]{
+    rdStructVarCurrent[int(VendorType::C)].assign({
             222.4698f/222.4698f, 228.8632f/222.4698f, 225.5057f/222.4698f, 226.3366f/222.4698f,
             227.9259f/222.4698f, 225.7385f/222.4698f, 225.3615f/222.4698f, 231.3116f/222.4698f
     });

--- a/src/equations.h
+++ b/src/equations.h
@@ -19,6 +19,8 @@ Released under the MIT License
 #include "config.h"
 #include "dramStruct.h"
 
+#include <memory>
+
 class Equations {
 protected:
     Statistics statistics;
@@ -30,7 +32,7 @@ protected:
     StructVar structVar;
 
     /* Lookup values for current variation based on structural variations */
-    std::shared_ptr<float[]> rdStructVarCurrent[int(VendorType::MAX)];                // For 8 banks
+    std::vector<float> rdStructVarCurrent[int(VendorType::MAX)];                // For 8 banks
     std::function<float(int)> actStructVarCurrent[int(VendorType::MAX)]; // For current based on LR model
 
 public:

--- a/src/vampire.cpp
+++ b/src/vampire.cpp
@@ -269,13 +269,13 @@ void Vampire::init_lambdas(){
 
 void Vampire::init_latencies() {
     // RD, WR, ACT, PRE
-    latency[int(VendorType::A)].reset(new float[int(CommandType::MAX)]{
+    latency[int(VendorType::A)]= (*new std::vector<float>{
             25.0, 25.0, 15.0, 15.0 //ns
     });
-    latency[int(VendorType::B)].reset(new float[int(CommandType::MAX)]{
+    latency[int(VendorType::B)]= (*new std::vector<float>{
             25.0, 25.0, 15.0, 15.0 //ns
     });
-    latency[int(VendorType::C)].reset(new float[int(CommandType::MAX)]{
+    latency[int(VendorType::C)]= (*new std::vector<float>   {
             23.125, 23.125, 13.125, 13.125 //ns
     });
 }

--- a/src/vampire.h
+++ b/src/vampire.h
@@ -73,7 +73,7 @@ protected:
     void init_latencies();
 
     /* Stores latency of each operation */
-    std::shared_ptr<float[]> latency[int(VendorType::MAX)];
+    std::vector<float> latency[int(VendorType::MAX)];
 
     /* Calculates # of set bits in data */
     std::function<unsigned int(unsigned int[16])> getSetBits[int(TraceType::MAX)];


### PR DESCRIPTION
This pull request contains following fixes:
1. Error on compiling VAMPIRE using non-c++17 compilers is now fixed. This release of vampire is tested with the following versions of g++ and clang++
  a) **g++**: *4.8.5*, *5.5.0* (20171010), *6.4.0* (20180424), *7.3.0*, *8.2.0*
  b) **clang++**: 6.0.0-1ubuntu2 (tags/RELEASE_600/final)
2. Makefile is now fixed and can compile vampire in two different modes:
  a) **Debug**: Running `make debug -j` will create a binary with flags retained to assist in debugging.
  b) **Release**: Running `make -j` or `make all -j` will create an optimized binary.
3. All `std::shared_ptr` objects for managing dynamic arrays are now replaced with std::vector.   

**NOTE**: Version number in the README is incremented to 1.0.1 to reflect these changes (Should we have a separate release history page?).